### PR TITLE
events array added to 'Finally set up Hocuspocus...' section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,9 @@ const server = Server.configure({
       secret: '459824aaffa928e05f5b1caec411ae5f',
 
       transformer: TiptapTransformer,
+
+      events: [Events.onConnect, Events.onCreate, Events.onChange, Events.onDisconnect],
+
     }),
   ],
 })


### PR DESCRIPTION
Addition of an array of events that the webhook extension for Hocuspocus needs to send to the Laravel api endpoint.

The logic cant work without all those events, as the default setup of the webhook extension is only the `Events.onChange` event. You can see this in the documentation [here](https://tiptap.dev/docs/hocuspocus/server/extensions/webhook#configuration)

```
// [optional] array of events that will trigger a webhook
// defaults to [ Events.onChange ]
      events: [Events.onConnect, Events.onCreate, Events.onChange, Events.onDisconnect],
```